### PR TITLE
Attachment tweaks

### DIFF
--- a/src/Epinova.ElasticSearch.Core.EPiServer/Indexer.cs
+++ b/src/Epinova.ElasticSearch.Core.EPiServer/Indexer.cs
@@ -190,7 +190,7 @@ namespace Epinova.ElasticSearch.Core.EPiServer
 
         private static bool IsExcludedType(Type type)
         {
-            if(type == null)
+            if(type?.Namespace?.StartsWith("Epinova.ElasticSearch", StringComparison.OrdinalIgnoreCase) != false)
             {
                 return true;
             }
@@ -221,7 +221,7 @@ namespace Epinova.ElasticSearch.Core.EPiServer
             {
                 return true;
             }
-            
+
             var deleted = GetEpiserverBoolProperty(content.Property["PageDeleted"]);
             if(deleted)
             {
@@ -240,7 +240,9 @@ namespace Epinova.ElasticSearch.Core.EPiServer
         {
             //This is already called to avoid indexing
             if(SkipIndexing(content))
+            {
                 return true;
+            }
 
             // Common property in Epinova template
             var hideFromSearch = GetEpiserverBoolProperty(content.Property["HideFromSearch"]);

--- a/src/Epinova.ElasticSearch.Core.EPiServer/Indexer.cs
+++ b/src/Epinova.ElasticSearch.Core.EPiServer/Indexer.cs
@@ -190,7 +190,7 @@ namespace Epinova.ElasticSearch.Core.EPiServer
 
         private static bool IsExcludedType(Type type)
         {
-            if(type?.Namespace?.StartsWith("Epinova.ElasticSearch", StringComparison.OrdinalIgnoreCase) != false)
+            if(type?.Namespace?.StartsWith("Epinova.ElasticSearch", StringComparison.OrdinalIgnoreCase) == true)
             {
                 return true;
             }

--- a/src/Epinova.ElasticSearch.Core.EPiServer/Initialization/IndexingInitializer.cs
+++ b/src/Epinova.ElasticSearch.Core.EPiServer/Initialization/IndexingInitializer.cs
@@ -1,6 +1,4 @@
-﻿using Epinova.ElasticSearch.Core.Conventions;
-using Epinova.ElasticSearch.Core.EPiServer.Events;
-using Epinova.ElasticSearch.Core.EPiServer.Models;
+﻿using Epinova.ElasticSearch.Core.EPiServer.Events;
 using EPiServer.Core;
 using EPiServer.DataAbstraction;
 using EPiServer.Framework;
@@ -14,9 +12,6 @@ namespace Epinova.ElasticSearch.Core.EPiServer.Initialization
     {
         public void Initialize(InitializationEngine context)
         {
-            Indexing.Instance.ExcludeType<SynonymBackupFile>();
-            Indexing.Instance.ExcludeType<SynonymBackupFileFolder>();
-
             IContentEvents events = context.Locate.Advanced.GetInstance<IContentEvents>();
 
             events.PublishedContent += IndexingEvents.UpdateIndex;

--- a/src/Epinova.ElasticSearch.Core/Contracts/IHttpClientHelper.cs
+++ b/src/Epinova.ElasticSearch.Core/Contracts/IHttpClientHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,6 +16,7 @@ namespace Epinova.ElasticSearch.Core.Contracts
         HttpStatusCode Head(Uri uri);
         Task<HttpStatusCode> HeadAsync(Uri uri);
         byte[] Post(Uri uri, byte[] data = null);
+        byte[] Post(Uri uri, Stream data = null);
         Task<byte[]> PostAsync(Uri uri, byte[] data, CancellationToken cancellationToken);
         void Put(Uri uri, byte[] data = null);
         Task PutAsync(Uri uri, byte[] data = null);

--- a/src/Epinova.ElasticSearch.Core/Utilities/HttpClientHelper.cs
+++ b/src/Epinova.ElasticSearch.Core/Utilities/HttpClientHelper.cs
@@ -212,7 +212,7 @@ namespace Epinova.ElasticSearch.Core.Utilities
                 }
                 catch
                 {
-                    Logger.Error($"Could not parse error-response: {error}");
+                    Logger.Error($"Could not parse error-response: {error}.\n Status: {(int)response.StatusCode} {response.StatusCode}");
                 }
             }
         }

--- a/src/Epinova.ElasticSearch.Core/Utilities/HttpClientHelper.cs
+++ b/src/Epinova.ElasticSearch.Core/Utilities/HttpClientHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -55,6 +56,40 @@ namespace Epinova.ElasticSearch.Core.Utilities
             catch(Exception ex)
             {
                 Logger.Error("Request failed", ex);
+            }
+        }
+
+        public byte[] Post(Uri uri, Stream stream)
+        {
+            Logger.Debug($"Uri: {uri}, Data: (stream)");
+
+            try
+            {
+                using(var streamContent = new StreamContent(stream))
+                {
+                    streamContent.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+                    var request = new HttpRequestMessage(HttpMethod.Post, uri)
+                    {
+                        Content = streamContent
+                    };
+                    request.Headers.ConnectionClose = false;
+
+                    HttpResponseMessage response = AsyncUtil.RunSync(() =>
+                        Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead)
+                    );
+
+                    LogErrorIfNotSuccess(response);
+
+                    return AsyncUtil.RunSync(() =>
+                          response.Content.ReadAsByteArrayAsync()
+                    );
+                }
+            }
+            catch(Exception ex)
+            {
+                Logger.Error("Request failed", ex);
+                return null;
             }
         }
 

--- a/src/Epinova.ElasticSearch.Core/Utilities/Indexing.cs
+++ b/src/Epinova.ElasticSearch.Core/Utilities/Indexing.cs
@@ -59,7 +59,7 @@ namespace Epinova.ElasticSearch.Core.Utilities
         {
             Logger.Information("Opening index");
 
-            _httpClientHelper.Post(GetUri(indexName, "_open"));
+            _httpClientHelper.Post(GetUri(indexName, "_open"), (byte[])null);
 
             var index = new Index(_settings, _httpClientHelper, indexName);
             index.WaitForStatus();
@@ -69,7 +69,7 @@ namespace Epinova.ElasticSearch.Core.Utilities
         {
             Logger.Information($"Closing index with delay of {_settings.CloseIndexDelay} ms");
 
-            _httpClientHelper.Post(GetUri(indexName, "_close"));
+            _httpClientHelper.Post(GetUri(indexName, "_close"), (byte[])null);
 
             var index = new Index(_settings, _httpClientHelper, indexName);
             index.WaitForStatus();

--- a/src/Epinova.ElasticSearch.Core/Utilities/MappingPatterns.cs
+++ b/src/Epinova.ElasticSearch.Core/Utilities/MappingPatterns.cs
@@ -9,6 +9,7 @@ namespace Epinova.ElasticSearch.Core.Utilities
     {
         private static readonly string TextType = nameof(MappingType.Text).ToLower();
         private static readonly string IntType = nameof(MappingType.Integer).ToLower();
+        private static readonly string LongType = nameof(MappingType.Long).ToLower();
 
         internal static dynamic GetTokenizerTemplate(string language, string tokenizer)
         {
@@ -61,7 +62,7 @@ namespace Epinova.ElasticSearch.Core.Utilities
             {
                 properties = new
                 {
-                    Id = new { type = "long" },
+                    Id = new { type = LongType },
                     StartPublish = new { type = "date" },
                     StopPublish = new { type = "date" },
                     Created = new { type = "date" },
@@ -69,16 +70,24 @@ namespace Epinova.ElasticSearch.Core.Utilities
                     Indexed = new { type = "date" },
                     Name = new { type = TextType, fields = Fields },
                     _bestbets = new { type = TextType, fields = Fields },
-                    ParentLink = new { type = "long" },
-                    Path = new { type = "long" },
+                    ParentLink = new { type = LongType },
+                    Path = new { type = LongType },
                     Lang = new { type = TextType },
                     DidYouMean = new { type = TextType, analyzer = languageName + "_suggest", fields = new { keyword = new { ignore_above = 8191, type = JsonNames.Keyword } } },
                     Suggest = SuggestMapping,
                     Type = new { type = TextType, analyzer = "raw", fields = Fields },
                     Types = new { type = TextType, analyzer = "raw" },
                     _acl = new { type = TextType, analyzer = "raw" },
-                    _attachmentdata = new { type = TextType },
+                    _attachmentdata = new { type = TextType, fields = Fields },
                     attachment = GetAttachmentMapping(languageName)
+                }
+                ,
+                _source = new
+                {
+                    excludes = new[]
+                    {
+                        DefaultFields.AttachmentData
+                    }
                 }
             };
         }
@@ -93,33 +102,14 @@ namespace Epinova.ElasticSearch.Core.Utilities
                     {
                         type = TextType,
                         term_vector = "with_positions_offsets",
-                        store = true,
+                        //store = false,
                         analyzer = languageName,
-                        fields = new
-                        {
-                            keyword = new
-                            {
-                                type = "keyword",
-                                ignore_above = 256
-                            }
-                        }
+                        fields = Fields
                     },
-                    title = new
-                    {
-                        type = TextType,
-                    },
-                    language = new
-                    {
-                        type = TextType,
-                    },
-                    content_type = new
-                    {
-                        type = TextType,
-                    },
-                    content_length = new
-                    {
-                        type = IntType,
-                    }
+                    title = new { type = TextType, fields = Fields },
+                    language = new { type = TextType, fields = Fields },
+                    content_type = new { type = TextType, fields = Fields },
+                    content_length = new { type = LongType }
                 }
             };
         }

--- a/src/Epinova.ElasticSearch.Core/Utilities/MappingPatterns.cs
+++ b/src/Epinova.ElasticSearch.Core/Utilities/MappingPatterns.cs
@@ -80,8 +80,7 @@ namespace Epinova.ElasticSearch.Core.Utilities
                     _acl = new { type = TextType, analyzer = "raw" },
                     _attachmentdata = new { type = TextType, fields = Fields },
                     attachment = GetAttachmentMapping(languageName)
-                }
-                ,
+                },
                 _source = new
                 {
                     excludes = new[]
@@ -102,7 +101,6 @@ namespace Epinova.ElasticSearch.Core.Utilities
                     {
                         type = TextType,
                         term_vector = "with_positions_offsets",
-                        //store = false,
                         analyzer = languageName,
                         fields = Fields
                     },

--- a/tests/Core.Episerver.Tests/IndexerTests.cs
+++ b/tests/Core.Episerver.Tests/IndexerTests.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using Epinova.ElasticSearch.Core.EPiServer;
 using Epinova.ElasticSearch.Core.EPiServer.Enums;
+using Epinova.ElasticSearch.Core.EPiServer.Models;
 using Epinova.ElasticSearch.Core.Models.Bulk;
 using EPiServer.Core;
 using EPiServer.Web;
@@ -349,6 +350,14 @@ namespace Core.Episerver.Tests
         {
             var content = Factory.GetPageData(shortcutType: shortcutType);
             var result = _indexer.SkipIndexing(content);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void IsExcludedType_ModuleType_ReturnsTrue()
+        {
+            var result = _indexer.IsExcludedType(new BestBetsFile());
 
             Assert.True(result);
         }

--- a/tests/Core.Tests/CoreIndexerTests.cs
+++ b/tests/Core.Tests/CoreIndexerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Net;
 using Epinova.ElasticSearch.Core;
 using Epinova.ElasticSearch.Core.Extensions;
@@ -60,7 +61,7 @@ namespace Core.Tests
             _coreIndexer.Bulk(new BulkOperation(new { Foo = "bar" }, "en", id, "my-index"));
 
             _fixture.ServiceLocationMock.HttpClientMock
-                .Verify(m => m.Post(new Uri($"http://example.com/_bulk?pipeline={Epinova.ElasticSearch.Core.Pipelines.Attachment.Name}"), It.IsAny<byte[]>()), Times.AtLeastOnce);
+                .Verify(m => m.Post(new Uri($"http://example.com/_bulk?pipeline={Epinova.ElasticSearch.Core.Pipelines.Attachment.Name}"), It.IsAny<Stream>()), Times.AtLeastOnce);
         }
 
         [Fact]


### PR DESCRIPTION
- Use stream instead of StringBuilder in Bulk()
- Remove AttachmentData from _source
- Index media files one by one regardless of bulk size
