### PR TITLE
Fix getting suggestions from other than default indexes

### DIFF
--- a/src/Epinova.ElasticSearch.Core.EPiServer/Extensions/QueryExtensions.cs
+++ b/src/Epinova.ElasticSearch.Core.EPiServer/Extensions/QueryExtensions.cs
@@ -56,7 +56,7 @@ namespace Epinova.ElasticSearch.Core.EPiServer.Extensions
 
             var request = new SuggestRequest(searchText, service.SizeValue, skipDuplicates);
 
-            var elasticSuggestions = engine.GetSuggestions(request, service.SearchLanguage);
+            var elasticSuggestions = engine.GetSuggestions(request, service.SearchLanguage, service.IndexName);
 
             var editorialSuggestions = repository.GetWords(Language.GetLanguageCode(service.CurrentLanguage))
                 .Where(w => w?.StartsWith(searchText) == true);


### PR DESCRIPTION
The IndexName from the service is not sent in to GetSuggestions.
If it is not set, it will resolve, as before, the default index.

Suggestions are not set in code on non-IContent types, but I have solved that with custom copy_to parameters in the mapping.