### PR TITLE
Add simple querystring search

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,7 @@ A search plugin for Episerver CMS and Commerce
 * File search
 * Range search (numerics and dates)
 * Fuzzy search
+* Simple querystring search
 * Facets
 * Filtering
 * Best Bets
@@ -200,6 +201,29 @@ SearchResult result = service
    .WildcardSearch<ArticlePage>("me?t")
    .GetResults();
 ```
+
+### Simple querystring search
+
+```csharp
+SearchResult result = service
+   .SimpleQuerystringSearch<ArticlePage>("(bacon | ham) melt -cheese")
+   .GetResults();
+```
+
+With limited operators:
+
+```csharp
+SearchResult result = service
+   .SimpleQuerystringSearch<ArticlePage>("\"bacon melt\" sandwi*",
+      defaultOperator: Operator.And,
+      allowedOperators:
+         SimpleQuerystringOperators.Prefix |
+         SimpleQuerystringOperators.Phrase);
+    )
+   .GetResults();
+```
+
+See https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html for syntax.
 
 ### Geo-point datatype
 

--- a/src/Epinova.ElasticSearch.Core/Contracts/IElasticSearchService{T}.cs
+++ b/src/Epinova.ElasticSearch.Core/Contracts/IElasticSearchService{T}.cs
@@ -24,6 +24,7 @@ namespace Epinova.ElasticSearch.Core.Contracts
         int FromValue { get; }
         int SizeValue { get; }
         bool IsWildcard { get; }
+        bool IsSimpleQuerystring { get; }
         bool IsGetQuery { get; }
         bool TrackSearch { get; }
 
@@ -539,6 +540,22 @@ namespace Epinova.ElasticSearch.Core.Contracts
         /// <param name="searchText">The text to search for</param>
         /// <returns>The current <see cref="IElasticSearchService"/> instance</returns>
         IElasticSearchService<T> WildcardSearch<T>(string searchText);
+
+        /// <summary>
+        /// Performs a generic simple querystring query on type <typeparamref name="T"/>
+        /// </summary>
+        /// <param name="searchText">The text to search for</param>
+        /// <param name="operator">Specifies the operator to use when searching, either <see cref="Enums.Operator.Or"/> or <see cref="Enums.Operator.And"/></param>
+        /// <returns>The current <see cref="IElasticSearchService"/> instance</returns>
+        IElasticSearchService<object> SimpleQuerystringSearch(string searchText, Operator @operator = Operator.Or);
+
+        /// <summary>
+        /// Performs a generic simple querystring query on type <typeparamref name="T"/>
+        /// </summary>
+        /// <param name="searchText">The text to search for</param>
+        /// <param name="operator">Specifies the operator to use when searching, either <see cref="Enums.Operator.Or"/> or <see cref="Enums.Operator.And"/></param>
+        /// <returns>The current <see cref="IElasticSearchService"/> instance</returns>
+        IElasticSearchService<T> SimpleQuerystringSearch<T>(string searchText, Operator @operator = Operator.Or);
 
         /// <summary>
         /// <para>

--- a/src/Epinova.ElasticSearch.Core/Contracts/IElasticSearchService{T}.cs
+++ b/src/Epinova.ElasticSearch.Core/Contracts/IElasticSearchService{T}.cs
@@ -27,6 +27,7 @@ namespace Epinova.ElasticSearch.Core.Contracts
         bool IsSimpleQuerystring { get; }
         bool IsGetQuery { get; }
         bool TrackSearch { get; }
+        SimpleQuerystringOperators SimpleQuerystringOperators { get; }
 
         /// <summary>
         /// Set your index name here if you want to use a different index from what is given in configuration.
@@ -545,17 +546,19 @@ namespace Epinova.ElasticSearch.Core.Contracts
         /// Performs a generic simple querystring query on type <typeparamref name="T"/>
         /// </summary>
         /// <param name="searchText">The text to search for</param>
-        /// <param name="operator">Specifies the operator to use when searching, either <see cref="Enums.Operator.Or"/> or <see cref="Enums.Operator.And"/></param>
+        /// <param name="defaultOperator">Specifies the operator to use when searching, either <see cref="Enums.Operator.Or"/> or <see cref="Enums.Operator.And"/></param>
+        /// <param name="allowedOperators">Specifies the supported operators for the simple query string syntax.</param>
         /// <returns>The current <see cref="IElasticSearchService"/> instance</returns>
-        IElasticSearchService<object> SimpleQuerystringSearch(string searchText, Operator @operator = Operator.Or);
+        IElasticSearchService<object> SimpleQuerystringSearch(string searchText, Operator defaultOperator = Operator.Or, SimpleQuerystringOperators allowedOperators = SimpleQuerystringOperators.All);
 
         /// <summary>
         /// Performs a generic simple querystring query on type <typeparamref name="T"/>
         /// </summary>
         /// <param name="searchText">The text to search for</param>
-        /// <param name="operator">Specifies the operator to use when searching, either <see cref="Enums.Operator.Or"/> or <see cref="Enums.Operator.And"/></param>
+        /// <param name="defaultOperator">Specifies the operator to use when searching, either <see cref="Enums.Operator.Or"/> or <see cref="Enums.Operator.And"/></param>
+        /// <param name="allowedOperators">Specifies the supported operators for the simple query string syntax.</param>
         /// <returns>The current <see cref="IElasticSearchService"/> instance</returns>
-        IElasticSearchService<T> SimpleQuerystringSearch<T>(string searchText, Operator @operator = Operator.Or);
+        IElasticSearchService<T> SimpleQuerystringSearch<T>(string searchText, Operator defaultOperator = Operator.Or, SimpleQuerystringOperators allowedOperators = SimpleQuerystringOperators.All);
 
         /// <summary>
         /// <para>

--- a/src/Epinova.ElasticSearch.Core/ElasticSearchService{T}.cs
+++ b/src/Epinova.ElasticSearch.Core/ElasticSearchService{T}.cs
@@ -67,6 +67,7 @@ namespace Epinova.ElasticSearch.Core
         public int SizeValue { get; private set; }
         public CultureInfo SearchLanguage { get; private set; }
         public bool IsSimpleQuerystring { get; private set; }
+        public SimpleQuerystringOperators SimpleQuerystringOperators { get; private set; }
 
         private string _indexName;
         private PrincipalInfo _aclPrincipal;
@@ -301,7 +302,8 @@ namespace Epinova.ElasticSearch.Core
                 IsSimpleQuerystring = IsSimpleQuerystring,
                 TrackSearch = TrackSearch,
                 IsGetQuery = IsGetQuery,
-                IndexName = IndexName
+                IndexName = IndexName,
+                SimpleQuerystringOperators = SimpleQuerystringOperators
             };
         }
 
@@ -399,7 +401,8 @@ namespace Epinova.ElasticSearch.Core
                 SortFields = SortFields,
                 UseBestBets = EnableBestBets,
                 UseHighlight = EnableHighlight,
-                IndexName = IndexName
+                IndexName = IndexName,
+                SimpleQuerystringOperators = SimpleQuerystringOperators
             };
         }
 
@@ -476,16 +479,16 @@ namespace Epinova.ElasticSearch.Core
             };
         }
 
-        public IElasticSearchService<object> SimpleQuerystringSearch(string searchText, Operator @operator = Operator.Or)
-            => SimpleQuerystringSearch<object>(searchText, @operator);
+        public IElasticSearchService<object> SimpleQuerystringSearch(string searchText, Operator defaultOperator = Operator.Or, SimpleQuerystringOperators allowedOperators = SimpleQuerystringOperators.All)
+            => SimpleQuerystringSearch<object>(searchText, defaultOperator, allowedOperators);
 
-        public IElasticSearchService<T> SimpleQuerystringSearch<T>(string searchText, Operator @operator = Operator.Or)
+        public IElasticSearchService<T> SimpleQuerystringSearch<T>(string searchText, Operator defaultOperator = Operator.Or, SimpleQuerystringOperators allowedOperators = SimpleQuerystringOperators.All)
         {
             return new ElasticSearchService<T>(_serverInfoService, _settings, _httpClientHelper)
             {
                 Type = typeof(T),
                 SearchText = searchText,
-                Operator = @operator,
+                Operator = defaultOperator,
                 SearchLanguage = SearchLanguage,
                 RootId = RootId,
                 SearchType = SearchType,
@@ -495,7 +498,8 @@ namespace Epinova.ElasticSearch.Core
                 SizeValue = SizeValue,
                 IsWildcard = false,
                 IndexName = IndexName,
-                IsSimpleQuerystring = true
+                IsSimpleQuerystring = true,
+                SimpleQuerystringOperators = allowedOperators,
             };
         }
 

--- a/src/Epinova.ElasticSearch.Core/ElasticSearchService{T}.cs
+++ b/src/Epinova.ElasticSearch.Core/ElasticSearchService{T}.cs
@@ -66,6 +66,7 @@ namespace Epinova.ElasticSearch.Core
         public int FromValue { get; private set; }
         public int SizeValue { get; private set; }
         public CultureInfo SearchLanguage { get; private set; }
+        public bool IsSimpleQuerystring { get; private set; }
 
         private string _indexName;
         private PrincipalInfo _aclPrincipal;
@@ -297,6 +298,7 @@ namespace Epinova.ElasticSearch.Core
                 FromValue = FromValue,
                 SizeValue = SizeValue,
                 IsWildcard = IsWildcard,
+                IsSimpleQuerystring = IsSimpleQuerystring,
                 TrackSearch = TrackSearch,
                 IsGetQuery = IsGetQuery,
                 IndexName = IndexName
@@ -391,6 +393,7 @@ namespace Epinova.ElasticSearch.Core
                 RootId = RootId,
                 IsWildcard = IsWildcard,
                 IsGetQuery = IsGetQuery,
+                IsSimpleQuerystring = IsSimpleQuerystring,
                 SourceFields = fields,
                 SearchType = SearchType,
                 SortFields = SortFields,
@@ -446,6 +449,7 @@ namespace Epinova.ElasticSearch.Core
                 FromValue = FromValue,
                 SizeValue = SizeValue,
                 IsWildcard = false,
+                IsSimpleQuerystring = false,
                 IndexName = IndexName
             };
         }
@@ -469,6 +473,29 @@ namespace Epinova.ElasticSearch.Core
                 SizeValue = SizeValue,
                 IsWildcard = true,
                 IndexName = IndexName
+            };
+        }
+
+        public IElasticSearchService<object> SimpleQuerystringSearch(string searchText, Operator @operator = Operator.Or)
+            => SimpleQuerystringSearch<object>(searchText, @operator);
+
+        public IElasticSearchService<T> SimpleQuerystringSearch<T>(string searchText, Operator @operator = Operator.Or)
+        {
+            return new ElasticSearchService<T>(_serverInfoService, _settings, _httpClientHelper)
+            {
+                Type = typeof(T),
+                SearchText = searchText,
+                Operator = @operator,
+                SearchLanguage = SearchLanguage,
+                RootId = RootId,
+                SearchType = SearchType,
+                UseBoosting = UseBoosting,
+                EnableBestBets = EnableBestBets,
+                FromValue = FromValue,
+                SizeValue = SizeValue,
+                IsWildcard = false,
+                IndexName = IndexName,
+                IsSimpleQuerystring = true
             };
         }
 

--- a/src/Epinova.ElasticSearch.Core/Engine/QueryBuilder.cs
+++ b/src/Epinova.ElasticSearch.Core/Engine/QueryBuilder.cs
@@ -142,15 +142,27 @@ namespace Epinova.ElasticSearch.Core.Engine
             }
             else
             {
-                request.Query.Bool.Must.Add(
-                    new MatchMulti(
-                        request.Query.SearchText,
-                        setup.SearchFields,
-                        setup.Operator,
-                        null,
-                        null,
-                        setup.FuzzyLength,
-                        setup.Analyzer));
+                if(setup.IsSimpleQuerystring)
+                {
+                    request.Query.Bool.Must.Add(
+                        new MatchSimpleQueryString(
+                            request.Query.SearchText,
+                            setup.SearchFields,
+                            setup.Operator,
+                            setup.Analyzer));
+                }
+                else
+                {
+                    request.Query.Bool.Must.Add(
+                        new MatchMulti(
+                            request.Query.SearchText,
+                            setup.SearchFields,
+                            setup.Operator,
+                            null,
+                            null,
+                            setup.FuzzyLength,
+                            setup.Analyzer));
+                }
 
                 // Boost phrase matches if multiple words
                 if(request.Query.SearchText?.IndexOf(" ", StringComparison.OrdinalIgnoreCase) > 0)

--- a/src/Epinova.ElasticSearch.Core/Engine/QueryBuilder.cs
+++ b/src/Epinova.ElasticSearch.Core/Engine/QueryBuilder.cs
@@ -149,6 +149,7 @@ namespace Epinova.ElasticSearch.Core.Engine
                             request.Query.SearchText,
                             setup.SearchFields,
                             setup.Operator,
+                            setup.SimpleQuerystringOperators,
                             setup.Analyzer));
                 }
                 else

--- a/src/Epinova.ElasticSearch.Core/Enums/SimpleQuerystringOperators.cs
+++ b/src/Epinova.ElasticSearch.Core/Enums/SimpleQuerystringOperators.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Epinova.ElasticSearch.Core.Enums
+{
+    /// <summary>
+    /// Represents operators supported by the simple query string syntax.
+    /// </summary>
+    [Flags]
+    public enum SimpleQuerystringOperators
+    {
+        /// <summary>
+        /// Disables all operators. 
+        /// </summary>
+        [EnumMember(Value = "NONE")]
+        None = 0,
+
+        /// <summary>
+        /// Enables the + AND operator. 
+        /// </summary>
+        [EnumMember(Value = "AND")]
+        And = 1,
+
+        /// <summary>
+        /// Enables \ as an escape character. 
+        /// </summary>
+        [EnumMember(Value = "ESCAPE")]
+        Escape = 2,
+
+        /// <summary>
+        /// Enables the ~N operator after a word, where N is an integer denoting the allowed edit distance for matching. See Fuzziness. 
+        /// </summary>
+        [EnumMember(Value = "FUZZY")]
+        Fuzzy = 4,
+
+        /// <summary>
+        /// Enables the ~N operator, after a phrase where N is the maximum number of positions allowed between matching tokens. Synonymous to SLOP. 
+        /// </summary>
+        [EnumMember(Value = "NEAR")]
+        Near = 8,
+
+        /// <summary>
+        /// Enables the - NOT operator. 
+        /// </summary>
+        [EnumMember(Value = "NOT")]
+        Not = 16,
+
+        /// <summary>
+        /// Enables the \| OR operator. 
+        /// </summary>
+        [EnumMember(Value = "OR")]
+        Or = 32,
+
+        /// <summary>
+        /// Enables the " quotes operator used to search for phrases. 
+        /// </summary>
+        [EnumMember(Value = "PHRASE")]
+        Phrase = 64,
+
+        /// <summary>
+        /// Enables the ( and ) operators to control operator precedence. 
+        /// </summary>
+        [EnumMember(Value = "PRECEDENCE")]
+        Precedence = 128,
+
+        /// <summary>
+        /// Enables the * prefix operator. 
+        /// </summary>
+        [EnumMember(Value = "PREFIX")]
+        Prefix = 256,
+
+        /// <summary>
+        /// Enables the ~N operator, after a phrase where N is maximum number of positions allowed between matching tokens. Synonymous to NEAR. 
+        /// </summary>
+        [EnumMember(Value = "SLOP")]
+        Slop = 512,
+
+        /// <summary>
+        /// Enables whitespace as split characters.
+        /// </summary>
+        [EnumMember(Value = "WHITESPACE")]
+        Whitespace = 1024,
+
+        /// <summary>
+        /// Enables all optional operators. (Default)
+        /// </summary>
+        [EnumMember(Value = "ALL")]
+        All = And | Escape | Fuzzy | Near | Not | Or | Phrase | Precedence | Prefix | Slop | Whitespace
+    }
+}

--- a/src/Epinova.ElasticSearch.Core/Epinova.ElasticSearch.Core.csproj
+++ b/src/Epinova.ElasticSearch.Core/Epinova.ElasticSearch.Core.csproj
@@ -278,6 +278,7 @@
     <Compile Include="Models\Query\Gauss.cs" />
     <Compile Include="Models\Query\GeoPolygon.cs" />
     <Compile Include="Models\Query\GeoDistance.cs" />
+    <Compile Include="Models\Query\MatchSimpleQueryString.cs" />
     <Compile Include="Models\Query\ScriptSort.cs" />
     <Compile Include="Models\Query\GeoSort.cs" />
     <Compile Include="Models\Query\Highlight.cs" />

--- a/src/Epinova.ElasticSearch.Core/Epinova.ElasticSearch.Core.csproj
+++ b/src/Epinova.ElasticSearch.Core/Epinova.ElasticSearch.Core.csproj
@@ -217,6 +217,7 @@
     <Compile Include="Enums\MappingConflict.cs" />
     <Compile Include="Enums\MappingType.cs" />
     <Compile Include="Enums\Operator.cs" />
+    <Compile Include="Enums\SimpleQuerystringOperators.cs" />
     <Compile Include="Events\BestBetEventArgs.cs" />
     <Compile Include="Events\Events.cs" />
     <Compile Include="Events\IndexItemEventArgs.cs" />

--- a/src/Epinova.ElasticSearch.Core/Extensions/EnumExtensions.cs
+++ b/src/Epinova.ElasticSearch.Core/Extensions/EnumExtensions.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Serialization;
+using Epinova.ElasticSearch.Core.Enums;
 
 namespace Epinova.ElasticSearch.Core.Extensions
 {
@@ -14,6 +16,30 @@ namespace Epinova.ElasticSearch.Core.Extensions
                 .Where(x => instance.HasFlag(x) && Convert.ToInt32(x) > 0)
                 .DefaultIfEmpty()
                 .Select(f => typeof(T).GetField(f.ToString()).GetCustomAttribute<DescriptionAttribute>()?.Description ?? f.ToString());
+        }
+
+        /// <summary>
+        /// Gets the value as elastic searchs json format for flags. (OR|AND|PREFIX)
+        /// </summary>
+        /// <param name="instance">Enum instance to format.</param>
+        /// <returns>Value in elastic search json format.</returns>
+        internal static string AsJsonValue(this SimpleQuerystringOperators instance)
+        {
+            if (instance == SimpleQuerystringOperators.All)
+            {
+                return typeof(SimpleQuerystringOperators)
+                    .GetField(nameof(SimpleQuerystringOperators.All))
+                    .GetCustomAttribute<EnumMemberAttribute>()?.Value ?? nameof(SimpleQuerystringOperators.All);
+            }
+            else
+            {
+                return
+                    string.Join("|",
+                        Enum.GetValues(typeof(SimpleQuerystringOperators)).Cast<SimpleQuerystringOperators>()
+                        .Where(x => instance.HasFlag(x) && Convert.ToInt32(x) > 0)
+                        .DefaultIfEmpty()
+                        .Select(f => typeof(SimpleQuerystringOperators).GetField(f.ToString()).GetCustomAttribute<EnumMemberAttribute>()?.Value ?? f.ToString()));
+            }
         }
     }
 }

--- a/src/Epinova.ElasticSearch.Core/Models/JsonNames.cs
+++ b/src/Epinova.ElasticSearch.Core/Models/JsonNames.cs
@@ -14,6 +14,7 @@
         public const string Component = "component";
         public const string Content = "content";
         public const string CopyTo = "copy_to";
+        public const string DefaultOperator = "default_operator";
         public const string DidYouMean = "dym";
         public const string Distance = "distance";
         public const string Doc = "doc";
@@ -87,6 +88,7 @@
         public const string ScoreRoot = "_score";
         public const string Score = "score";
         public const string Should = "should";
+        public const string SimpleQuerystring = "simple_query_string";
         public const string Size = "size";
         public const string SkipDuplicates = "skip_duplicates";
         public const string Sort = "sort";

--- a/src/Epinova.ElasticSearch.Core/Models/JsonNames.cs
+++ b/src/Epinova.ElasticSearch.Core/Models/JsonNames.cs
@@ -25,6 +25,7 @@
         public const string FieldData = "fielddata";
         public const string Fields = "fields";
         public const string Filter = "filter";
+        public const string Flags = "flags";
         public const string Format = "format";
         public const string From = "from";
         public const string FunctionScore = "function_score";

--- a/src/Epinova.ElasticSearch.Core/Models/Query/MatchSimpleQueryString.cs
+++ b/src/Epinova.ElasticSearch.Core/Models/Query/MatchSimpleQueryString.cs
@@ -1,19 +1,21 @@
 ﻿using System.Collections.Generic;
 using Epinova.ElasticSearch.Core.Enums;
+using Epinova.ElasticSearch.Core.Extensions;
 using Newtonsoft.Json;
 
 namespace Epinova.ElasticSearch.Core.Models.Query
 {
     internal sealed class MatchSimpleQueryString : MatchBase
     {
-        public MatchSimpleQueryString(string query, List<string> fields, Operator @operator, string analyzer = null)
+        public MatchSimpleQueryString(string query, List<string> fields, Operator @operator, SimpleQuerystringOperators flags = SimpleQuerystringOperators.All, string analyzer = null)
         {
             SimpleQueryString = new SimpleQueryStringInternal
             {
                 Query = query,
                 DefaultOperator = @operator.ToString().ToLower(),
                 Fields = fields,
-                Analyzer = analyzer
+                Analyzer = analyzer,
+                Flags = flags.AsJsonValue()
             };
         }
 
@@ -30,6 +32,9 @@ namespace Epinova.ElasticSearch.Core.Models.Query
 
             [JsonProperty(JsonNames.Analyzer)]
             public string Analyzer { get; internal set; }
+
+            [JsonProperty(JsonNames.Flags)]
+            public string Flags { get; internal set; }
 
             [JsonProperty(JsonNames.Fields)]
             public List<string> Fields { get; internal set; }

--- a/src/Epinova.ElasticSearch.Core/Models/Query/MatchSimpleQueryString.cs
+++ b/src/Epinova.ElasticSearch.Core/Models/Query/MatchSimpleQueryString.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using Epinova.ElasticSearch.Core.Enums;
+using Newtonsoft.Json;
+
+namespace Epinova.ElasticSearch.Core.Models.Query
+{
+    internal sealed class MatchSimpleQueryString : MatchBase
+    {
+        public MatchSimpleQueryString(string query, List<string> fields, Operator @operator, string analyzer = null)
+        {
+            SimpleQueryString = new SimpleQueryStringInternal
+            {
+                Query = query,
+                DefaultOperator = @operator.ToString().ToLower(),
+                Fields = fields,
+                Analyzer = analyzer
+            };
+        }
+
+        public class SimpleQueryStringInternal
+        {
+            [JsonProperty(JsonNames.Query)]
+            public string Query { get; internal set; }
+
+            [JsonProperty(JsonNames.Lenient)]
+            public bool Lenient => true;
+
+            [JsonProperty(JsonNames.DefaultOperator)]
+            public string DefaultOperator { get; internal set; }
+
+            [JsonProperty(JsonNames.Analyzer)]
+            public string Analyzer { get; internal set; }
+
+            [JsonProperty(JsonNames.Fields)]
+            public List<string> Fields { get; internal set; }
+        }
+
+        [JsonProperty(JsonNames.SimpleQuerystring)]
+        public SimpleQueryStringInternal SimpleQueryString { get; private set; }
+    }
+}

--- a/src/Epinova.ElasticSearch.Core/Models/QuerySetup.cs
+++ b/src/Epinova.ElasticSearch.Core/Models/QuerySetup.cs
@@ -72,5 +72,6 @@ namespace Epinova.ElasticSearch.Core.Models
         public bool AppendAclFilters { get; internal set; }
         public PrincipalInfo AclPrincipal { get; internal set; }
         public Version ServerVersion { get; internal set; }
+        public SimpleQuerystringOperators SimpleQuerystringOperators { get; set; }
     }
 }

--- a/src/Epinova.ElasticSearch.Core/Models/QuerySetup.cs
+++ b/src/Epinova.ElasticSearch.Core/Models/QuerySetup.cs
@@ -52,6 +52,7 @@ namespace Epinova.ElasticSearch.Core.Models
         public int Size { get; set; }
         public bool IsWildcard { get; set; }
         public bool IsGetQuery { get; set; }
+        public bool IsSimpleQuerystring { get; set; }
         public List<Filter> Filters { get; set; }
         public Dictionary<string, FilterGroupQuery> FilterGroups { get; set; }
         public Type SearchType { get; set; }

--- a/tests/Core.Tests/Core.Tests.csproj
+++ b/tests/Core.Tests/Core.Tests.csproj
@@ -186,6 +186,7 @@
   <ItemGroup>
     <Compile Include="Admin\HealthTests.cs" />
     <Compile Include="Admin\IndexTests.cs" />
+    <Compile Include="Extensions\EnumExtensionsTests.cs" />
     <Compile Include="ServerInfoTests.cs" />
     <Compile Include="CoreIndexerTests.cs" />
     <Compile Include="BulkOperationTests.cs" />

--- a/tests/Core.Tests/ElasticSearchServiceTests.cs
+++ b/tests/Core.Tests/ElasticSearchServiceTests.cs
@@ -371,5 +371,13 @@ namespace Core.Tests
 
             Assert.True(result.IsGetQuery);
         }
+
+        [Fact]
+        public void SimpleQuerystringSearch_SetsFlag()
+        {
+            var result = _service.SimpleQuerystringSearch<TestPage>("test-query");
+
+            Assert.True(result.IsSimpleQuerystring);
+        }
     }
 }

--- a/tests/Core.Tests/Engine/QueryBuilderTests.cs
+++ b/tests/Core.Tests/Engine/QueryBuilderTests.cs
@@ -649,7 +649,6 @@ namespace Core.Tests.Engine
 
         [Theory]
         [InlineData("SimpleQuerystring_Term_Foo.json", "Foo")]
-        [InlineData("SimpleQuerystring_Term_Foo_Bar.json", "Foo Bar")]
         public void Search_SimpleQuerystring_ReturnsExpectedJson(string testFile, string term)
         {
             var expected = RemoveWhitespace(GetJsonTestData(testFile));
@@ -658,6 +657,27 @@ namespace Core.Tests.Engine
             {
                 IsSimpleQuerystring = true,
                 SearchText = term,
+                SimpleQuerystringOperators = SimpleQuerystringOperators.All,
+                Language = _language
+            })));
+
+            Assert.Contains(expected, result);
+        }
+
+        [Theory]
+        [InlineData("SimpleQuerystring_Term_Foo_Bar_And_Near_Or.json", "Foo Bar")]
+        public void Search_SimpleQuerystring_ReturnsExpectedJson_With_Flags(string testFile, string term)
+        {
+            var expected = RemoveWhitespace(GetJsonTestData(testFile));
+
+            string result = RemoveWhitespace(Serialize(_builder.Search(new QuerySetup
+            {
+                IsSimpleQuerystring = true,
+                SearchText = term,
+                SimpleQuerystringOperators = 
+                    SimpleQuerystringOperators.And | 
+                    SimpleQuerystringOperators.Near |
+                    SimpleQuerystringOperators.Or,
                 Language = _language
             })));
 

--- a/tests/Core.Tests/Engine/QueryBuilderTests.cs
+++ b/tests/Core.Tests/Engine/QueryBuilderTests.cs
@@ -633,6 +633,37 @@ namespace Core.Tests.Engine
             Assert.True(result);
         }
 
+        [Fact]
+        public void SimpleQueryString_AddsMatchSimpleQueryString()
+        {
+            var request = (QueryRequest)_builder.Search(new QuerySetup
+            {
+                IsSimpleQuerystring = true,
+                SearchText = "term"
+            });
+
+            var result = request.Query.Bool.Must.Cast<MatchSimpleQueryString>().Any();
+
+            Assert.True(result);
+        }
+
+        [Theory]
+        [InlineData("SimpleQuerystring_Term_Foo.json", "Foo")]
+        [InlineData("SimpleQuerystring_Term_Foo_Bar.json", "Foo Bar")]
+        public void Search_SimpleQuerystring_ReturnsExpectedJson(string testFile, string term)
+        {
+            var expected = RemoveWhitespace(GetJsonTestData(testFile));
+
+            string result = RemoveWhitespace(Serialize(_builder.Search(new QuerySetup
+            {
+                IsSimpleQuerystring = true,
+                SearchText = term,
+                Language = _language
+            })));
+
+            Assert.Contains(expected, result);
+        }
+
         private static string Serialize(object data)
         {
             return JsonConvert.SerializeObject(data,

--- a/tests/Core.Tests/Extensions/EnumExtensionsTests.cs
+++ b/tests/Core.Tests/Extensions/EnumExtensionsTests.cs
@@ -1,0 +1,31 @@
+﻿using Epinova.ElasticSearch.Core.Enums;
+using Epinova.ElasticSearch.Core.Extensions;
+using Xunit;
+
+namespace Core.Tests.Extensions
+{
+    public class EnumExtensionsTests
+    {
+        [Fact]
+        public void AsJsonValue_Returns_Values()
+        {
+            var value = SimpleQuerystringOperators.Not | 
+                        SimpleQuerystringOperators.Or | 
+                        SimpleQuerystringOperators.Phrase;
+
+            Assert.Equal("NOT|OR|PHRASE", value.AsJsonValue());
+        }
+
+        [Fact]
+        public void AsJsonValue_Returns_None_As_Single_Value()
+        {
+            Assert.Equal("NONE", SimpleQuerystringOperators.None.AsJsonValue());
+        }
+
+        [Fact]
+        public void AsJsonValue_Returns_All_As_Single_Value()
+        {
+            Assert.Equal("ALL", SimpleQuerystringOperators.All.AsJsonValue());
+        }
+    }
+}

--- a/tests/TestData/Json/SimpleQuerystring_Term_Foo.json
+++ b/tests/TestData/Json/SimpleQuerystring_Term_Foo.json
@@ -4,6 +4,7 @@
       "query": "foo",
       "lenient": true,
       "default_operator": "or",
+      "flags": "ALL",
       "fields": [
         "bar",
         "attachment.content",

--- a/tests/TestData/Json/SimpleQuerystring_Term_Foo.json
+++ b/tests/TestData/Json/SimpleQuerystring_Term_Foo.json
@@ -1,0 +1,15 @@
+﻿"must": [
+  {
+    "simple_query_string": {
+      "query": "foo",
+      "lenient": true,
+      "default_operator": "or",
+      "fields": [
+        "bar",
+        "attachment.content",
+        "attachment.author",
+        "attachment.keywords"
+      ]
+    }
+  }
+]

--- a/tests/TestData/Json/SimpleQuerystring_Term_Foo_Bar.json
+++ b/tests/TestData/Json/SimpleQuerystring_Term_Foo_Bar.json
@@ -1,0 +1,15 @@
+﻿"must": [
+  {
+    "simple_query_string": {
+      "query": "foo bar",
+      "lenient": true,
+      "default_operator": "or",
+      "fields": [
+        "bar",
+        "attachment.content",
+        "attachment.author",
+        "attachment.keywords"
+      ]
+    }
+  }
+]

--- a/tests/TestData/Json/SimpleQuerystring_Term_Foo_Bar_And_Near_Or.json
+++ b/tests/TestData/Json/SimpleQuerystring_Term_Foo_Bar_And_Near_Or.json
@@ -4,6 +4,7 @@
       "query": "foo bar",
       "lenient": true,
       "default_operator": "or",
+      "flags": "AND|NEAR|OR",
       "fields": [
         "bar",
         "attachment.content",

--- a/tests/TestData/TestData.csproj
+++ b/tests/TestData/TestData.csproj
@@ -208,6 +208,8 @@
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
+    <None Include="Json\SimpleQuerystring_Term_Foo_Bar.json" />
+    <None Include="Json\SimpleQuerystring_Term_Foo.json" />
     <None Include="Json\Settings.json" />
     <None Include="Json\NodeInfo.json" />
     <None Include="Json\HealthInfo.json" />

--- a/tests/TestData/TestData.csproj
+++ b/tests/TestData/TestData.csproj
@@ -208,7 +208,7 @@
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="Json\SimpleQuerystring_Term_Foo_Bar.json" />
+    <None Include="Json\SimpleQuerystring_Term_Foo_Bar_And_Near_Or.json" />
     <None Include="Json\SimpleQuerystring_Term_Foo.json" />
     <None Include="Json\Settings.json" />
     <None Include="Json\NodeInfo.json" />


### PR DESCRIPTION
Add SimpleQuerystringSearch<T>() method to allow using elastics simple_query_sring syntax.

Simple query string reference:
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html

Example:
```
SearchResult result = service
   .SimpleQuerystringSearch<ArticlePage>("(bacon | ham) melt -cheese")
   .GetResults();
```

Allowed operators can be limited with allowedOperations parameter:

```
SearchResult result = service
   .SimpleQuerystringSearch<ArticlePage>("\"bacon melt\" sandwi*",
      defaultOperator: Operator.And,
      allowedOperators:
         SimpleQuerystringOperators.Prefix |
         SimpleQuerystringOperators.Phrase);
    )
   .GetResults();
```
