### PR TITLE
Properly mapping returned custom fields from search results to their …

### DIFF
--- a/tests/Core.Tests/Engine/SearchEngineTests.cs
+++ b/tests/Core.Tests/Engine/SearchEngineTests.cs
@@ -142,8 +142,8 @@ namespace Core.Tests.Engine
             Assert.Equal(text, result.Hits.First().CustomProperties["Text"]);
             Assert.Equal(lng1, result.Hits.First().CustomProperties["Int"]);
             Assert.Equal(dec1, result.Hits.First().CustomProperties["Dec"]);
-            Assert.True(Factory.ArrayEquals(arr1, result.Hits.First().CustomProperties["Array1"] as IEnumerable<object>));
-            Assert.True(Factory.ArrayEquals(arr2, result.Hits.First().CustomProperties["Array2"] as IEnumerable<object>));
+            Assert.True(Factory.ArrayEquals(arr1, result.Hits.First().CustomProperties["Array1"] as IEnumerable<long>));
+            Assert.True(Factory.ArrayEquals(arr2, result.Hits.First().CustomProperties["Array2"] as IEnumerable<string>));
         }
 
         [Fact]


### PR DESCRIPTION
These are the changes I've outlined in Issue: https://github.com/Epinova/Epinova.Elasticsearch/issues/133

To summarize:

_Custom fields are not being mapped properly when pulling from the returned set of search results. Complex objects don't come back at all and result in the error: Unable to cast object of type 'Newtonsoft.Json.Linq.JObject' to type 'Newtonsoft.Json.Linq.JValue. Because of this it requires developers using the library to map these custom fields on their own._

This PR will fix this and send the custom fields on the _Customs_ dictionary as their original type.