### PR TITLE
Feature/fallback analyser

### DIFF
--- a/src/Epinova.ElasticSearch.Core/Utilities/Analyzers.cs
+++ b/src/Epinova.ElasticSearch.Core/Utilities/Analyzers.cs
@@ -73,9 +73,16 @@ namespace Epinova.ElasticSearch.Core.Utilities
 
         private static dynamic GetSuggestAnalyzer(string languageName)
         {
+            var filter = new[] { "lowercase", languageName + "_stop" };
+
+            if(languageName == "fallback")
+            {
+                filter = new[] { "lowercase" };
+            }
+
             return new
             {
-                filter = new[] { "lowercase", languageName + "_stop" },
+                filter,
                 char_filter = analyzerCharFilter,
                 tokenizer = "uax_url_email"
             };
@@ -99,8 +106,12 @@ namespace Epinova.ElasticSearch.Core.Utilities
                 dict.Add("english_possessive_stemmer", new { type = "stemmer", language = "possessive_english" });
             }
 
-            dict.Add(languageName + "_stop", new { type = "stop", stopwords = "_" + languageName + "_" });
-            dict.Add(languageName + "_stemmer", new { type = "stemmer", language = stemmerLanguage });
+            if(languageName != "fallback")
+            {
+                dict.Add(languageName + "_stemmer", new { type = "stemmer", language = stemmerLanguage });
+                dict.Add(languageName + "_stop", new { type = "stop", stopwords = "_" + languageName + "_" });
+            }
+
             dict.Add(languageName + "_synonym_filter", synonymSettings);
 
             return filter;
@@ -115,12 +126,12 @@ namespace Epinova.ElasticSearch.Core.Utilities
                 yield return "english_possessive_stemmer";
                 yield return "light_english_stemmer";
             }
-            else
+            else if (languageName != "fallback")
             {
                 yield return languageName + "_stemmer";
+                yield return languageName + "_stop";
             }
 
-            yield return languageName + "_stop";
             yield return "shingle_filter";
         }
 
@@ -170,7 +181,11 @@ namespace Epinova.ElasticSearch.Core.Utilities
             }
 
             yield return "lowercase";
-            yield return languageName + "_stop";
+
+            if (languageName != "fallback")
+            {
+                yield return languageName + "_stop";
+            }
 
             if(languageName == "german")
             {
@@ -194,7 +209,11 @@ namespace Epinova.ElasticSearch.Core.Utilities
                 yield return "english_possessive_stemmer";
             }
 
-            yield return languageName + "_stop";
+            if (languageName != "fallback")
+            {
+                yield return languageName + "_stop";
+                yield return languageName + "_stemmer";
+            }
 
             if(languageName == "german")
             {
@@ -202,7 +221,6 @@ namespace Epinova.ElasticSearch.Core.Utilities
             }
 
             yield return languageName + "_synonym_filter";
-            yield return languageName + "_stemmer";
         }
     }
 }

--- a/src/Epinova.ElasticSearch.Core/Utilities/Language.cs
+++ b/src/Epinova.ElasticSearch.Core/Utilities/Language.cs
@@ -14,15 +14,41 @@ namespace Epinova.ElasticSearch.Core.Utilities
         /// </summary>
         private static readonly Dictionary<string, string> AnalyzerMappings = new Dictionary<string, string>
         {
+            { "ar", "arabic" },
+            { "am", "armenian" },
+            { "eu", "basque" },
+            { "bn", "bengali" },
+            { "pt-br", "brazilian" },
+            { "bg", "bulgarian" },
+            { "ca", "catalan" },
+            //{ "", "cjk" },    Don't know the language code for this. If you do feel free to add it.
+            { "cs", "czech" },
             { "da", "danish" },
-            { "en", "english" },
-			{ "us", "english" },
-            { "fr", "french" },
-            { "de", "german" },
-            { "no", "norwegian" },
             { "nl", "dutch" },
+            { "en", "english" },
+            { "us", "english" },
+            { "fi", "finnish" },
+            { "fr", "french" },
+            { "gl", "galican" },
+            { "de", "german" },
+            { "el", "greek" },
+            { "hi", "hindi" },
+            { "hu", "hungarian" },
+            { "id", "indonesian" },
+            { "ga", "irish" },
+            { "it", "italian" },
+            { "lv", "latvian" },
+            { "lt", "lithuanian" },
+            { "no", "norwegian" },
+            { "fa", "persian" },
+            { "pt", "portuguese" },
+            { "ro", "romanian" },
+            { "ru", "russian" },
+            //{ "", "sorani" },     Don't know the language code for this. If you do feel free to add it.
             { "es", "spanish" },
-            { "sv", "swedish" }
+            { "sv", "swedish" },
+            { "tr", "turkish" },
+            { "th", "thai" }
         };
 
         internal static string GetRequestLanguageCode()

--- a/src/Epinova.ElasticSearch.Core/Utilities/Language.cs
+++ b/src/Epinova.ElasticSearch.Core/Utilities/Language.cs
@@ -103,7 +103,7 @@ namespace Epinova.ElasticSearch.Core.Utilities
         {
             if(language == null)
             {
-                return null;
+                return "fallback";
             }
 
             if(AnalyzerMappings.TryGetValue(language, out string analyzer))
@@ -111,7 +111,7 @@ namespace Epinova.ElasticSearch.Core.Utilities
                 return analyzer;
             }
 
-            return null;
+            return "fallback";
         }
 
         internal static CultureInfo GetRequestLanguage()

--- a/tests/Core.Tests/Utilities/LanguageTests.cs
+++ b/tests/Core.Tests/Utilities/LanguageTests.cs
@@ -85,9 +85,9 @@ namespace Core.Tests.Utilities
         [InlineData("es", "spanish")]
         [InlineData("sv", "swedish")]
         [InlineData("nl", "dutch")]
-        [InlineData(null, null)]
-        [InlineData("", null)]
-        [InlineData("foo", null)]
+        [InlineData(null, "fallback")]
+        [InlineData("", "fallback")]
+        [InlineData("foo", "fallback")]
         public void GetLanguageAnalyzer_ReturnsCorrectAnalyzerForLanguage(string language, string expectedAnalyzer)
         {
             string result = Language.GetLanguageAnalyzer(language);


### PR DESCRIPTION
Fjerner stop words og stemmer fra oppsettet av indeksen når det er et språk som ikke har default analyser. Usikker på om det er en tilfredsstillende løsning, men indeksering og søk fungerer.