### PR TITLE
Assets indexing improvements and fixes for synonyms.

### DIFF
--- a/src/Epinova.ElasticSearch.Core/Settings/Configuration/FilesCollection.cs
+++ b/src/Epinova.ElasticSearch.Core/Settings/Configuration/FilesCollection.cs
@@ -44,6 +44,9 @@ namespace Epinova.ElasticSearch.Core.Settings.Configuration
         [ConfigurationProperty("enabled", IsRequired = true, DefaultValue = true)]
         public bool Enabled => (bool)base["enabled"];
 
+        [ConfigurationProperty("disableContentIndexing", IsRequired = false, DefaultValue = false)]
+        public bool DisableContentIndexing => (bool)base["disableContentIndexing"];
+
         public FileConfiguration this[int index]
         {
             get => (FileConfiguration)BaseGet(index);

--- a/src/Epinova.ElasticSearch.Core/Settings/ElasticSearchSettings.cs
+++ b/src/Epinova.ElasticSearch.Core/Settings/ElasticSearchSettings.cs
@@ -68,6 +68,8 @@ namespace Epinova.ElasticSearch.Core.Settings
 
         public bool EnableFileIndexing => _configuration.Files.Enabled;
 
+        public bool DisableContentIndexing => _configuration.Files.DisableContentIndexing;
+
         public bool IgnoreXhtmlStringContentFragments => _configuration.IgnoreXhtmlStringContentFragments;
 
         /// <summary>

--- a/src/Epinova.ElasticSearch.Core/Settings/IElasticSearchSettings.cs
+++ b/src/Epinova.ElasticSearch.Core/Settings/IElasticSearchSettings.cs
@@ -8,6 +8,7 @@ namespace Epinova.ElasticSearch.Core.Settings
         int BulkSize { get; }
         long DocumentMaxSize { get; }
         bool EnableFileIndexing { get; }
+        bool DisableContentIndexing { get; }
         string Host { get; }
         string Username { get; }
         string Password { get; }

--- a/src/Epinova.ElasticSearch.Core/Utilities/Analyzers.cs
+++ b/src/Epinova.ElasticSearch.Core/Utilities/Analyzers.cs
@@ -182,6 +182,8 @@ namespace Epinova.ElasticSearch.Core.Utilities
 
             yield return "lowercase";
 
+            yield return languageName + "_synonym_filter";
+
             if (languageName != "fallback")
             {
                 yield return languageName + "_stop";
@@ -191,8 +193,6 @@ namespace Epinova.ElasticSearch.Core.Utilities
             {
                 yield return "german_normalization";
             }
-
-            yield return languageName + "_synonym_filter";
         }
 
         private static IEnumerable<string> CreateAnalyzerFilter(string languageName)
@@ -209,7 +209,9 @@ namespace Epinova.ElasticSearch.Core.Utilities
                 yield return "english_possessive_stemmer";
             }
 
-            if (languageName != "fallback")
+            yield return languageName + "_synonym_filter";
+
+            if(languageName != "fallback")
             {
                 yield return languageName + "_stop";
                 yield return languageName + "_stemmer";
@@ -219,8 +221,6 @@ namespace Epinova.ElasticSearch.Core.Utilities
             {
                 yield return "german_normalization";
             }
-
-            yield return languageName + "_synonym_filter";
         }
     }
 }


### PR DESCRIPTION
- Added ability to disable indexing of assets contents (only filenames are indexed, useful when a search is only used for assets searching in EPI Admin Panel).
- Fixed synonyms filter location and file parsing.