### PR TITLE
Make top 50px visible again (CMS11)

### DIFF
--- a/src/Epinova.ElasticSearch.Core.EPiServer/Views/ElasticSearchAdmin/_ElasticSearch.cshtml
+++ b/src/Epinova.ElasticSearch.Core.EPiServer/Views/ElasticSearchAdmin/_ElasticSearch.cshtml
@@ -114,6 +114,10 @@
         .indexes {
             padding: 0;
         }
+        
+        #epi-globalDocument {
+            padding-top: 50px; /* CMS 11 padding top issue */
+        }
     </style>
 
     @RenderSection("Styles", false)


### PR DESCRIPTION
Add padding-top so fixed top menu doesn't cover the top 50px of admin pages.